### PR TITLE
Update setup.py

### DIFF
--- a/src/DecoID/DecoID.py
+++ b/src/DecoID/DecoID.py
@@ -85,15 +85,20 @@ def collapseAsNeeded(spectra,targetRes):
 def solveSystem(S,o,resPenalty,maxQuant=1000):
     return deconvolveLASSO(np.transpose(S), [[x] for x in o], [0 for _ in S], [maxQuant for _ in S], resPenalty=resPenalty)
 
-def normalizeSpectra(spectra,method="sum"):
-    if method == "sum": maxSpec = np.sum(spectra)
-    else: maxSpec = np.max(spectra)
-    if np.isinf(np.power(np.float(maxSpec/maxSpec),2)) or np.isnan(np.power(np.float(maxSpec/maxSpec),2)):
+def normalizeSpectra(spectra, method="sum"):
+    if method == "sum": 
+        maxSpec = np.sum(spectra)
+    else: 
+        maxSpec = np.max(spectra)
+        
+    # Check if maxSpec is zero or NaN
+    if maxSpec == 0 or np.isnan(maxSpec):
         return [0.0 for x in spectra]
+    
     normSpec = [x/maxSpec for x in spectra]
     if np.max(normSpec) > 1.1:
         return [0.0 for x in spectra]
-    return [x/maxSpec for x in spectra]
+    return normSpec
 
 def isPossible(query,candidate,threshold=.75):
     if len(candidate.keys()) == 0:

--- a/src/DecoID/DecoID.py
+++ b/src/DecoID/DecoID.py
@@ -168,14 +168,20 @@ def dotProductSpectra(foundSpectra,b,mz1=-1,mz2=-1,polarity=-1):
         mzs = set(foundSpectra.keys()).intersection(set(b.keys())) #get shared mzs
         num = np.sum([foundSpectra[x]*b[x] for x in mzs]) #compute num
         denom = np.sqrt(np.sum([x**2 for x in foundSpectra.values()])*sum([x**2 for x in b.values()])) #compute denom
-        val = num/denom
     #if input spectra are lists
     else:
         b = flatten(b) #flatten spectra
         foundSpectra = flatten(foundSpectra)
-        val = np.sum([x*y for x,y in zip(b,foundSpectra) if x > 1e-4 or y > 1e-4])/np.sqrt(np.sum([x**2 for x in foundSpectra])*(np.sum( #compute value
-                [x**2 for x in b])))
-    if np.isnan(val): val = 0
+        num = np.sum([x*y for x,y in zip(b,foundSpectra) if x > 1e-4 or y > 1e-4])
+        denom = np.sqrt(np.sum([x**2 for x in foundSpectra])*(np.sum([x**2 for x in b])))
+
+    if denom == 0:
+        val = 0
+    else:
+        val = num/denom
+        if np.isnan(val):
+            val = 0
+
     return val
 
 def safeNormalize(vec):

--- a/src/setup.py
+++ b/src/setup.py
@@ -13,7 +13,7 @@ setup(
   keywords = ['Metabolomics', 'Deconvolution', 'MS/MS',"Metabolite ID"],   # Keywords that define your package best
   install_requires=[            # I get to this in a second
           'numpy',
-          'sklearn',
+          'scikit-learn',
           'pandas',
           'dill',
           'scipy',


### PR DESCRIPTION
Changed sklearn -> scikit-learn

It looks like pip no longer recognizes sklearn and refuses to install dependencies using pip:
```
Collecting sklearn (from decoid)
  Using cached sklearn-0.0.post7.tar.gz (3.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      
      If the previous advice does not cover your use case, feel free to report it at
      https://github.com/scikit-learn/sklearn-pypi-package/issues/new
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

With this update, I am able to pip install DecoID without problem, and I am able to run the tests provided in the README.